### PR TITLE
Changed RemoveAt to match vanilla behavior.

### DIFF
--- a/GrowPatch/GrowPatch.cs
+++ b/GrowPatch/GrowPatch.cs
@@ -117,7 +117,7 @@ namespace GrowPatch
 		[Header("Settings")]
 		public float muiltiplier = 1f;
 
-		public float removeAt = 30f;
+		public float removeAt = 40f;
 
 		private ProjectileHit projectileHit;
 


### PR DESCRIPTION
In vanilla, the `TrickShot` mono is removed after 40 units, not 30.

![image](https://user-images.githubusercontent.com/11213059/232844838-7547522d-5547-4afd-8e8f-c6e6086fb4ac.png)
